### PR TITLE
Add zd_domain option for those who re-brand Zendesk

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'rake'
 require 'echoe'
 
-Echoe.new('zendesk-api', '0.3.2') do |p|
+Echoe.new('zendesk-api', '0.3.4') do |p|
   p.description     = "RubyGem wrapper for REST API to http://zendesk.com"
   p.author          = "Peter Ericson"
   p.url             = "http://github.com/pgericson/zendesk-api"

--- a/lib/zendesk/main.rb
+++ b/lib/zendesk/main.rb
@@ -13,11 +13,12 @@ module Zendesk
       else
         @format = 'xml'
       end
+      @zd_domain = options[:zd_domain] ? options[:zd_domain] : "zendesk.com"
     end
 
     def main_url
       url_prefix    = @options[:ssl] ? "https://" : "http://"
-      url_postfix   = ".zendesk.com/"
+      url_postfix   = ".#{@zd_domain}/"
       url = url_prefix + @account + url_postfix
     end
 

--- a/spec/zendesk/main_spec.rb
+++ b/spec/zendesk/main_spec.rb
@@ -9,11 +9,11 @@ describe Zendesk::Main, "basic" do
     @zendesk = Zendesk::Main.new(@account, @username, @password)
   end
 
-  it "should have the correct mail_url with no ssl options" do
+  it "should have the correct main_url with no ssl options" do
     @zendesk.main_url.should == "http://#{@account}.zendesk.com/"
   end
 
-  it "should have the correct mail_url with ssl options" do
+  it "should have the correct main_url with ssl options" do
     @zendesk = Zendesk::Main.new(@account, @username, @password, :ssl => true)
     @zendesk.main_url.should == "https://#{@account}.zendesk.com/"
   end

--- a/spec/zendesk/main_spec.rb
+++ b/spec/zendesk/main_spec.rb
@@ -17,6 +17,11 @@ describe Zendesk::Main, "basic" do
     @zendesk = Zendesk::Main.new(@account, @username, @password, :ssl => true)
     @zendesk.main_url.should == "https://#{@account}.zendesk.com/"
   end
+  
+  it "should have the correct main_url with zd_domain option" do
+    @zendesk = Zendesk::Main.new(@account, @username, @password, :zd_domain => "shopkeep.com")
+    @zendesk.main_url.should == "http://#{@account}.shopkeep.com/"
+  end
 end
 
 describe Zendesk::Main, 'make_request' do

--- a/zendesk-api.gemspec
+++ b/zendesk-api.gemspec
@@ -2,11 +2,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{zendesk-api}
-  s.version = "0.3.3"
+  s.version = "0.3.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 1.2") if s.respond_to? :required_rubygems_version=
   s.authors = ["Peter Ericson"]
-  s.date = %q{2010-12-27}
+  s.date = %q{2011-04-07}
   s.description = %q{RubyGem wrapper for REST API to http://zendesk.com}
   s.email = %q{pg.ericson@gmail.com}
   s.extra_rdoc_files = ["README.markdown", "lib/console.rb", "lib/zendesk-api.rb", "lib/zendesk.rb", "lib/zendesk/attachment.rb", "lib/zendesk/entry.rb", "lib/zendesk/forum.rb", "lib/zendesk/group.rb", "lib/zendesk/main.rb", "lib/zendesk/organization.rb", "lib/zendesk/search.rb", "lib/zendesk/tag.rb", "lib/zendesk/ticket.rb", "lib/zendesk/user.rb", "lib/zendesk/user_identity.rb"]


### PR DESCRIPTION
The organization that I'm working for re-brands Zendesk using their own domain.

Added a ":zd_domain => mydomain.com" option .. defaults to "zendesk.com" if not supplied. Added test for new option.
