### PR TITLE
Add list of supported API Endpoints to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,19 @@ Bundler install:
 
     gem "zendesk-api", "latestversion"
 
+## Supported v1 Endpoints
+
+* Attachments
+* Comments
+* Entries
+* Forums
+* Groups
+* Organizations
+* Search
+* Tags
+* Tickets
+* Users
+
 ## How to use it
 ### Basic
 Below outputs xml


### PR DESCRIPTION
With the Zendesk API currently at v2, having the list of endpoints that this gem supports would be helpful for reference. 
